### PR TITLE
wic: implement binary repeatable disk identifiers

### DIFF
--- a/scripts/lib/wic/plugins/imager/direct.py
+++ b/scripts/lib/wic/plugins/imager/direct.py
@@ -313,7 +313,10 @@ class PartitionedImage():
                           # all partitions (in bytes)
         self.ptable_format = ptable_format  # Partition table format
         # Disk system identifier
-        self.identifier = random.SystemRandom().randint(1, 0xffffffff)
+        if os.getenv('SOURCE_DATE_EPOCH'):
+            self.identifier = random.Random(int(os.getenv('SOURCE_DATE_EPOCH'))).randint(1, 0xffffffff)
+        else:
+            self.identifier = random.SystemRandom().randint(1, 0xffffffff)
 
         self.partitions = partitions
         self.partimages = []


### PR DESCRIPTION
When SOURCE_DATE_EPOCH variable is set, binary repeatable build is expected. This commit implements reproducable disk identifiers in such a case using its value as a Random seed.




taken from openembedded-core: 2c0c54e12169e76f16fb3398904bc897a9190397